### PR TITLE
ci: migrate to goreleaser v2 and bump goreleaser-action to v6

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -28,7 +28,7 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,9 +9,18 @@ on:
       - "scripts/**"
       - "*.md"
       - ".github/**"
+      - ".goreleaser.yml"
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - ".run/**"
+      - "templates/**"
+      - "scripts/**"
+      - "*.md"
+      - ".github/**"
+      - ".goreleaser.yml"
     branches:
       - master
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - go mod tidy
@@ -28,7 +29,8 @@ builds:
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - id: zip
-    format: zip
+    formats:
+      - zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'


### PR DESCRIPTION
## Summary

Completes the goreleaser v6 / v2 migration that was deferred from the modernization PR (#107). Closes the original dependabot PR #78 in spirit.

Also tightens the CI trigger so future release-/CI-only PRs don't burn ~50 min of acceptance-test minutes.

## Changes

- `.goreleaser.yml`:
  - Add `version: 2` directive (required by goreleaser v2).
  - Switch deprecated `archives.format: zip` to the v2 `archives.formats: [zip]` list syntax.
- `.github/workflows/tag.yml`:
  - Bump `goreleaser/goreleaser-action` from `v5` to `v6` (v6 defaults to `~> v2`).
- `.github/workflows/tests.yaml`:
  - Mirror existing `push` `paths-ignore` on the `pull_request` trigger so docs / CI / release-only PRs skip the matrix.
  - Add `.goreleaser.yml` to both ignore lists so future goreleaser config-only changes don't trigger tests either.

## Local verification

Against `goreleaser v2.15.4`:

```
goreleaser check                                  ✓ (no deprecation warnings)
goreleaser build --snapshot --clean --single-target  ✓ (build succeeded)
```

## Test plan

- [ ] On merge, next `v*` tag push exercises the Release workflow; expectation: identical artifacts/signature behaviour as before.
- [ ] After this lands, a follow-up PR that touches only `.github/**`, `docs/**`, `*.md`, or `.goreleaser.yml` should show all matrix jobs as "Skipped".
- [ ] If anything regresses, the previous `v5` release setup is one commit back in history.

## Notes

There is no CI gating goreleaser itself — `tag.yml` only runs on tag pushes. The unit_test + acc_test matrix on this PR was already triggered by the initial push (and passed); the latest commit (paths-ignore for `.github/**`) intentionally skips re-running the matrix.